### PR TITLE
fix "Learn More" link in documentation section

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,8 @@
                         <p class="leading-relaxed text-base">Check out the documentation to learn how MELODY is
                             built.
                         </p>
-                        <a class="mt-3 text-green-500 inline-flex items-center">Learn More
+                        <a class="mt-3 text-green-500 inline-flex items-center"
+                            href="documentation/documentation.html">Learn More
                             <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
                                 stroke-width="2" class="w-4 h-4 ml-2" viewBox="0 0 24 24">
                                 <path d="M5 12h14M12 5l7 7-7 7"></path>


### PR DESCRIPTION
Currently, the "Learn More" link in the documentation section on the index page doesn't link to anything. This PR adds the href to the documentation page.